### PR TITLE
Fixes bug on paths with spaces; Fixes bug parsing non-Windows output.

### DIFF
--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -41,7 +41,7 @@ function getIndexOfNextTestGeneral(lines: string[], curIndex: number): number {
 }
 
 export function parseTestResults(stdout: string, testSuitName: string): TestResult[] | string[] {
-    var lines: string[] = stdout.split("\r\n");
+    var lines: string[] = stdout.replaceAll("\r","").split("\n");
 
     var isStart: boolean = true;
     var results: TestResult[] = [];

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -16,7 +16,7 @@ export function runTest(run: TestRun, test: TestItem): TestResult[] | string[] {
         });
 
         try {
-            const command = `swipl -s ${test.uri?.fsPath} -g "set_test_options([format(log),timeout(20)]) , (run_tests(${testSuitName}) -> true ; true)" -t halt 2>&1`;
+            const command = `swipl -s "${test.uri?.fsPath}" -g "set_test_options([format(log),timeout(20)]) , (run_tests(${testSuitName}) -> true ; true)" -t halt 2>&1`;
 
             var out = execSync(command, {encoding: 'utf-8'});
             return parseTestResults(out, testSuitName);
@@ -33,7 +33,7 @@ export function runTest(run: TestRun, test: TestItem): TestResult[] | string[] {
         run.started(test);
         
         try {
-            const command = `swipl -s ${test.uri?.fsPath} -g "set_test_options([format(log),timeout(20)]) , (run_tests(${testSuitName}:${testName}) -> true ; true)" -t halt 2>&1`;
+            const command = `swipl -s "${test.uri?.fsPath}" -g "set_test_options([format(log),timeout(20)]) , (run_tests(${testSuitName}:${testName}) -> true ; true)" -t halt 2>&1`;
 
             var startTime = Date.now();
             var out = execSync(command, {encoding: 'utf-8'});


### PR DESCRIPTION
The extension failed on two points:
- Working directory had spaces in the path, fixed with quotes around the command;
- Output parser assumed `\r\n` for newlines, which only works on Windows; fixed by filtering out `\r` and splitting on `\n`.